### PR TITLE
Fixed warnings with Ruby 2.7 on Proc.new with no block.

### DIFF
--- a/lib/awesome_print/formatters/base_formatter.rb
+++ b/lib/awesome_print/formatters/base_formatter.rb
@@ -109,8 +109,8 @@ module AwesomePrint
         inspector.current_indentation
       end
 
-      def indented
-        inspector.increase_indentation(&Proc.new)
+      def indented(&block)
+        inspector.increase_indentation(&block)
       end
 
       def indent

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -62,8 +62,8 @@ module AwesomePrint
       indentator.indentation
     end
 
-    def increase_indentation
-      indentator.indent(&Proc.new)
+    def increase_indentation(&block)
+      indentator.indent(&block)
     end
 
     # Dispatcher that detects data nesting and invokes object-aware formatter.


### PR DESCRIPTION
- Ref: https://github.com/ruby/ruby/commit/9f1fb0a17febc59356d58cef5e98db61a3c03550